### PR TITLE
Add wait argument and use for describe-db-instances

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@ bin/rds -c create-db-snapshot
 bin/rds -c describe-db-snapshots -i my-other-db-instance-identifier
 ```
 
+## Wait for instance status to be available
+Useful if you are modifying a db-parameter-group or upgrading a DB instance
+```sh
+bin/rds -c describe-db-instances --wait
+```
+
 ## Customized commands
 the `Commands` module contains overides for some client methods to customize responses to output what ever is most pertinant, add waiting or doing anything else the client is able to do.
 

--- a/bin/rds
+++ b/bin/rds
@@ -53,7 +53,7 @@ def snapshot_identifier
 end
 
 def request
-  return send(command, db_identifier) if self.methods.include?(command)
+  return send(command, db_identifier, options) if self.methods.include?(command)
 
   response = client.send(command, db_identifier)
   response.to_h

--- a/lib/rds_opt_parser.rb
+++ b/lib/rds_opt_parser.rb
@@ -25,6 +25,12 @@ class RdsOptParser
         options.identifier = id
       end
 
+      opts.on('-w',
+              '--wait',
+              'Optional: wait until status of instance is "availale".') do |bool|
+        options.wait = bool
+      end
+
       opts.on_tail('-h', '--help', 'Show this message') do
         puts opts
         exit


### PR DESCRIPTION
Enable waiting for an instance to be available.

Useful for modifying db instance db-parameter-groups
and db upgrade itself.

Example output:
```
upgrading..........................................................................................................configuring-enhanced-monitoring.......modifying........available.done
[
    [0] {
            :db_instance_status => "available",
        :db_instance_identifier => "redacted",
             :db_instance_class => "db.t3.medium",
                        :engine => "postgres v13.1",
           :db_parameter_groups => [
            [0] {
                :db_parameter_group_name => "redacted",
                 :parameter_apply_status => "in-sync"
            }
        ]
    }
]
```